### PR TITLE
Can no longer pass null to strpos

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,11 @@
     "name": "klaude/eloquent-preferences",
     "type": "library",
     "description": "Preferences for Laravel Eloquent models",
-    "keywords": ["laravel", "eloquent", "preferences"],
+    "keywords": [
+        "laravel",
+        "eloquent",
+        "preferences"
+    ],
     "homepage": "https://github.com/klaude/eloquent-preferences",
     "license": "MIT",
     "authors": [
@@ -13,8 +17,8 @@
     ],
     "require": {
         "ext-json": "*",
-        "illuminate/database": "~5|~6.0|~7.0|~8.0|~9.0|~10.0",
-        "illuminate/support": "~5|~6.0|~7.0|~8.0|~9.0|~10.0"
+        "illuminate/database": "~5|~6.0|~7.0|~8.0|~9.0|~10.0|~11.0",
+        "illuminate/support": "~5|~6.0|~7.0|~8.0|~9.0|~10.0|~11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "ext-json": "*",
-        "illuminate/database": "~5|~6.0|~7.0|~8.0|~9.0",
-        "illuminate/support": "~5|~6.0|~7.0|~8.0|~9.0"
+        "illuminate/database": "~5|~6.0|~7.0|~8.0|~9.0|~10.0",
+        "illuminate/support": "~5|~6.0|~7.0|~8.0|~9.0|~10.0"
     },
     "autoload": {
         "psr-4": {
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "ext-pdo": "*",
-        "illuminate/events": "~5|~6.0|~7.0|~8.0|~9.0",
+        "illuminate/events": "~5|~6.0|~7.0|~8.0|~9.0|~10.0",
         "phpunit/phpunit": "~5.0|~4.8"
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "ext-json": "*",
-        "illuminate/database": "~5|~6.0|~7.0|~8.0",
-        "illuminate/support": "~5|~6.0|~7.0|~8.0"
+        "illuminate/database": "~5|~6.0|~7.0|~8.0|~9.0",
+        "illuminate/support": "~5|~6.0|~7.0|~8.0|~9.0"
     },
     "autoload": {
         "psr-4": {
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "ext-pdo": "*",
-        "illuminate/events": "~5|~6.0|~7.0|~8.0",
+        "illuminate/events": "~5|~6.0|~7.0|~8.0|~9.0",
         "phpunit/phpunit": "~5.0|~4.8"
     },
     "autoload-dev": {

--- a/src/HasPreferences.php
+++ b/src/HasPreferences.php
@@ -303,7 +303,7 @@ trait HasPreferences
         }
 
         // Case Eloquent >= 5.7 compatible types
-        if (method_exists($this, 'asDecimal') && strpos($castTo, 'decimal:') === 0) {
+        if (method_exists($this, 'asDecimal') && $castTo && strpos($castTo, 'decimal:') === 0) {
             return $this->asDecimal($value, explode(':', $castTo, 2)[1]);
         }
 


### PR DESCRIPTION
From PHP 8.1 Release notes https://www.php.net/releases/8.1/en.php

> Passing null to non-nullable internal function parameters is deprecated.

This PR fixes the following error when `null` is passed to strpos

```
Deprecated: strpos(): Passing null to parameter #1 ($haystack)
```